### PR TITLE
feat(markdown-renderer): 添加自定义图片和视频渲染组件, 增加响应式样式，提升用户体验

### DIFF
--- a/packages/components/src/markdown-renderer/blocks/image.tsx
+++ b/packages/components/src/markdown-renderer/blocks/image.tsx
@@ -1,0 +1,22 @@
+import classNames from "classnames"
+
+interface IImageProps {
+	className?: string
+	alt?: string
+	src: string
+}
+
+/**
+ * 图片渲染组件
+ */
+export default function ImageBlock(props: IImageProps) {
+
+	const { className, src, alt } = props
+
+	const imgClassNames = classNames({
+		"w-full h-full max-w-[500px] rounded-lg mt-2": true,
+		[`${className}`]: !!className
+	})
+
+	return <img className={imgClassNames} alt={alt || '图片加载失败'} src={src} />
+}

--- a/packages/components/src/markdown-renderer/blocks/video.tsx
+++ b/packages/components/src/markdown-renderer/blocks/video.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames"
+
+/**
+ * 视频渲染组件
+ */
+export const VideoBlock = (props: HTMLVideoElement & {
+	children?: React.ReactNode
+}) => {
+	const { className, children, ...videoProps } = props
+
+	const videoClassNames = classNames({
+		"w-full h-full max-w-[500px] rounded-lg mt-2": true,
+		[`${className}`]: !!className
+	})
+
+	return (
+		// @ts-expect-error TODO: 类型待优化
+		<video
+			{...videoProps}
+			className={videoClassNames}
+			controls
+		>
+			{children}
+		</video>
+	)
+}
+
+export default VideoBlock


### PR DESCRIPTION
新增 ImageBlock 和 VideoBlock 组件用于渲染 markdown 中的图片和视频。优化 markdown 文本处理逻辑，确保图片标签正确渲染。移除旧的 Img 组件，使用新的 ImageBlock 替代。

### Description

<img width="389" alt="image" src="https://github.com/user-attachments/assets/4c2b14c0-217d-4ff1-aa5c-dabd065af9b4" />

### Linked Issues

Close #200 .
