### PR TITLE
fix: 新建对话未能清除当前对话内容

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,6 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          source-root: web
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/web/components/chat/chatbox-wrapper.tsx
+++ b/web/components/chat/chatbox-wrapper.tsx
@@ -43,10 +43,7 @@ export default function ChatboxWrapper(props: IChatboxWrapperProps) {
 		conversationItemsChangeCallback,
 		handleStartConfig,
 	} = props
-	const {
-		currentConversationId,
-		setCurrentConversationId,
-	} = useDifyChatStore()
+	const { currentConversationId, setCurrentConversationId } = useDifyChatStore()
 	const setConversations = useDifyChatStore(s => s.setConversations)
 	const conversations = useDifyChatStore(s => s.conversations)
 	const currentConversationInfo = conversations?.find(item => item.id === currentConversationId)
@@ -292,7 +289,7 @@ export default function ChatboxWrapper(props: IChatboxWrapperProps) {
 	}
 
 	useEffect(() => {
-		if (!messagesloadingEnabled) {
+		if (!messagesloadingEnabled && !isTempId(currentConversationId)) {
 			setMessagesloadingEnabled(true)
 		} else {
 			// 只有允许 loading 时，才清空对话列表数据
@@ -348,7 +345,7 @@ export default function ChatboxWrapper(props: IChatboxWrapperProps) {
 			return {
 				id: item.id,
 				status: item.status,
-				
+
 				error: item.message?.error || '',
 				workflows: item.message?.workflows,
 				agentThoughts: item.message?.agentThoughts,


### PR DESCRIPTION
## 问题

新建对话时，如果 `messagesloadingEnabled` 为 `false`，当前代码会走到「开启 loading」分支而不是「清空旧内容」分支，导致旧对话的消息残留。

## 根因

`chatbox-wrapper.tsx` 的 `useEffect` 在 `currentConversationId` 变化时，仅通过 `messagesloadingEnabled` 状态判断是否清空，没有考虑新 ID 的类型。临时 ID（`temp_xxx`）代表用户主动创建的新对话，应该无条件清空旧状态。

## 修复

在条件中增加 `&& !isTempId(currentConversationId)`：

```diff
- if (!messagesloadingEnabled) {
+ if (!messagesloadingEnabled && !isTempId(currentConversationId)) {
```

当 `currentConversationId` 是临时 ID 时，无论 `messagesloadingEnabled` 为何值，都走清空路径。

Closes #379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message-loading state handling when switching conversations to prevent unintended re-enabling for temporary conversations. This ensures message loading only resumes under the correct conditions, reducing flicker and incorrect loading states when navigating between saved and temporary chats for a smoother, more reliable chat experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lexmin0412/dify-chat/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->