### PR TITLE
feat: add wide-screen toggle in header (#381)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -403,3 +403,8 @@ declare namespace JSX {
 		'em-emoji':any;
 	}
 }
+
+/* 宽屏模式 */
+html.wide-screen .md\:max-w-\[720px\] {
+	max-width: none;
+}

--- a/web/components/chat/chat-layout.tsx
+++ b/web/components/chat/chat-layout.tsx
@@ -409,31 +409,37 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				<HeaderLayout
 					title={renderCenterTitle?.(currentApp?.config?.info)}
 					rightIcon={
-						<div className="flex items-center gap-4">
-							{!isMobile && (
-								<div
-									className="flex cursor-pointer items-center"
-									onClick={() => setIsWideScreen(!isWideScreen)}
-									title={isWideScreen ? '切换窄屏' : '切换宽屏'}
-								>
-									<LucideIcon
-										name={isWideScreen ? 'shrink' : 'stretch-horizontal'}
-										size={20}
-									/>
-								</div>
-							)}
-							{isMobile ? (
-								<Dropdown
-									menu={{
-										className: '!pb-3 w-[80vw]',
-										activeKey: currentConversationId,
-										items: mobileMenuItems,
-									}}
-								>
-									<MenuOutlined className="text-xl" />
-								</Dropdown>
-							) : null}
-						</div>
+						isMobile ? (
+							<Dropdown
+								menu={{
+									className: '!pb-3 w-[80vw]',
+									activeKey: currentConversationId,
+									items: mobileMenuItems,
+								}}
+							>
+								<MenuOutlined className="text-xl" />
+							</Dropdown>
+						) : null
+					}
+					renderRightIcons={
+						isMobile
+							? undefined
+							: ({ theme, github }) => (
+									<div className="flex items-center gap-4">
+										<div
+											className="flex cursor-pointer items-center"
+											onClick={() => setIsWideScreen(!isWideScreen)}
+											title={isWideScreen ? '切换窄屏' : '切换宽屏'}
+										>
+											<LucideIcon
+												name={isWideScreen ? 'shrink' : 'stretch-horizontal'}
+												size={20}
+											/>
+										</div>
+										{theme}
+										{github}
+									</div>
+								)
 					}
 				/>
 

--- a/web/components/chat/chat-layout.tsx
+++ b/web/components/chat/chat-layout.tsx
@@ -26,7 +26,7 @@ import {
 import dayjs from 'dayjs'
 import { useSearchParams } from 'next/navigation'
 import React, { useEffect, useEffectEvent, useMemo, useState } from 'react'
-
+import { useLocalStorageState } from 'ahooks'
 import AppIcon from '@/components/chat/chatbox/app-icon'
 import { AppInfo } from '@/components/chat/chatbox/app-info'
 import { LucideIcon } from '@/components/shared'
@@ -394,6 +394,14 @@ export default function ChatLayout(props: IChatLayoutProps) {
 		useDifyChatStore.getState().setCurrentConversationId(currentConversationId)
 	}, [conversations, currentConversationId])
 
+	const [isWideScreen, setIsWideScreen] = useLocalStorageState('dify-chat-wide-screen', {
+		defaultValue: false,
+	})
+
+	useEffect(() => {
+		document.documentElement.classList.toggle('wide-screen', isWideScreen)
+	}, [isWideScreen])
+
 	return (
 		<>
 			<div className={`bg-theme-bg flex h-screen w-full flex-col overflow-hidden`}>
@@ -401,17 +409,31 @@ export default function ChatLayout(props: IChatLayoutProps) {
 				<HeaderLayout
 					title={renderCenterTitle?.(currentApp?.config?.info)}
 					rightIcon={
-						isMobile ? (
-							<Dropdown
-								menu={{
-									className: '!pb-3 w-[80vw]',
-									activeKey: currentConversationId,
-									items: mobileMenuItems,
-								}}
-							>
-								<MenuOutlined className="text-xl" />
-							</Dropdown>
-						) : null
+						<div className="flex items-center gap-4">
+							{!isMobile && (
+								<div
+									className="flex cursor-pointer items-center"
+									onClick={() => setIsWideScreen(!isWideScreen)}
+									title={isWideScreen ? '切换窄屏' : '切换宽屏'}
+								>
+									<LucideIcon
+										name={isWideScreen ? 'shrink' : 'stretch-horizontal'}
+										size={20}
+									/>
+								</div>
+							)}
+							{isMobile ? (
+								<Dropdown
+									menu={{
+										className: '!pb-3 w-[80vw]',
+										activeKey: currentConversationId,
+										items: mobileMenuItems,
+									}}
+								>
+									<MenuOutlined className="text-xl" />
+								</Dropdown>
+							) : null}
+						</div>
 					}
 				/>
 

--- a/web/components/shared/header-layout.tsx
+++ b/web/components/shared/header-layout.tsx
@@ -1,9 +1,10 @@
 import { LucideIcon } from '@/components/shared'
 import { useIsMobile } from '@/lib/helpers'
 import { ThemeSelector, useThemeContext } from '@/lib/theme'
+import { useLocalStorageState } from 'ahooks'
 import { Space } from 'antd'
 import classNames from 'classnames'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import CenterTitleWrapper from './center-title-wrapper'
 import { GithubIcon, Logo } from './logo'
@@ -52,6 +53,13 @@ export default function HeaderLayout(props: IHeaderLayoutProps) {
 	const { isTitleWrapped, title, rightIcon, logoText, renderLogo } = props
 	const { themeMode } = useThemeContext()
 	const isMobile = useIsMobile()
+	const [isWideScreen, setIsWideScreen] = useLocalStorageState('dify-chat-wide-screen', {
+		defaultValue: false,
+	})
+
+	useEffect(() => {
+		document.documentElement.classList.toggle('wide-screen', isWideScreen)
+	}, [isWideScreen])
 	return (
 		<div className="flex h-16 items-center justify-between px-4">
 			{/* 🌟 Logo */}
@@ -74,6 +82,16 @@ export default function HeaderLayout(props: IHeaderLayoutProps) {
 						className="flex items-center"
 						size={16}
 					>
+						<div
+							className="flex cursor-pointer items-center"
+							onClick={() => setIsWideScreen(!isWideScreen)}
+							title={isWideScreen ? '切换窄屏' : '切换宽屏'}
+						>
+							<LucideIcon
+								name={isWideScreen ? 'shrink' : 'stretch-horizontal'}
+								size={20}
+							/>
+						</div>
 						<ThemeSelector>
 							<div className="flex cursor-pointer items-center">
 								<LucideIcon

--- a/web/components/shared/header-layout.tsx
+++ b/web/components/shared/header-layout.tsx
@@ -18,9 +18,16 @@ export interface IHeaderLayoutProps {
 	 */
 	isTitleWrapped?: boolean
 	/**
-	 * 自定义右侧图标
+	 * 自定义右侧图标（完全替换默认图标）
 	 */
 	rightIcon?: React.ReactNode
+	/**
+	 * 自定义右侧图标布局（按槽位重组，比 rightIcon 更灵活）
+	 *
+	 * @param slots.theme 主题切换按钮
+	 * @param slots.github GitHub 链接图标
+	 */
+	renderRightIcons?: (slots: { theme: React.ReactNode; github: React.ReactNode }) => React.ReactNode
 	/**
 	 * Logo 文本
 	 */
@@ -49,9 +56,36 @@ const HeaderSiderIcon = (props: { align: 'left' | 'right'; children: React.React
  * 头部布局组件
  */
 export default function HeaderLayout(props: IHeaderLayoutProps) {
-	const { isTitleWrapped, title, rightIcon, logoText, renderLogo } = props
+	const { isTitleWrapped, title, rightIcon, renderRightIcons, logoText, renderLogo } = props
 	const { themeMode } = useThemeContext()
 	const isMobile = useIsMobile()
+
+	const themeSlot = (
+		<ThemeSelector>
+			<div className="flex cursor-pointer items-center">
+				<LucideIcon
+					name={themeMode === 'dark' ? 'moon-star' : themeMode === 'light' ? 'sun' : 'screen-share'}
+					size={20}
+				/>
+			</div>
+		</ThemeSelector>
+	)
+
+	const githubSlot = <GithubIcon />
+
+	const defaultRightIcons = (
+		<Space
+			className="flex items-center"
+			size={16}
+		>
+			{themeSlot}
+			{githubSlot}
+		</Space>
+	)
+
+	const finalRightIcons = renderRightIcons
+		? renderRightIcons({ theme: themeSlot, github: githubSlot })
+		: rightIcon || defaultRightIcons
 	return (
 		<div className="flex h-16 items-center justify-between px-4">
 			{/* 🌟 Logo */}
@@ -68,30 +102,7 @@ export default function HeaderLayout(props: IHeaderLayoutProps) {
 			{isTitleWrapped ? title : <CenterTitleWrapper>{title}</CenterTitleWrapper>}
 
 			{/* 右侧图标 */}
-			<HeaderSiderIcon align="right">
-				{rightIcon || (
-					<Space
-						className="flex items-center"
-						size={16}
-					>
-						<ThemeSelector>
-							<div className="flex cursor-pointer items-center">
-								<LucideIcon
-									name={
-										themeMode === 'dark'
-											? 'moon-star'
-											: themeMode === 'light'
-												? 'sun'
-												: 'screen-share'
-									}
-									size={20}
-								/>
-							</div>
-						</ThemeSelector>
-						<GithubIcon />
-					</Space>
-				)}
-			</HeaderSiderIcon>
+			<HeaderSiderIcon align="right">{finalRightIcons}</HeaderSiderIcon>
 		</div>
 	)
 }

--- a/web/components/shared/header-layout.tsx
+++ b/web/components/shared/header-layout.tsx
@@ -1,10 +1,9 @@
 import { LucideIcon } from '@/components/shared'
 import { useIsMobile } from '@/lib/helpers'
 import { ThemeSelector, useThemeContext } from '@/lib/theme'
-import { useLocalStorageState } from 'ahooks'
 import { Space } from 'antd'
 import classNames from 'classnames'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import CenterTitleWrapper from './center-title-wrapper'
 import { GithubIcon, Logo } from './logo'
@@ -53,13 +52,6 @@ export default function HeaderLayout(props: IHeaderLayoutProps) {
 	const { isTitleWrapped, title, rightIcon, logoText, renderLogo } = props
 	const { themeMode } = useThemeContext()
 	const isMobile = useIsMobile()
-	const [isWideScreen, setIsWideScreen] = useLocalStorageState('dify-chat-wide-screen', {
-		defaultValue: false,
-	})
-
-	useEffect(() => {
-		document.documentElement.classList.toggle('wide-screen', isWideScreen)
-	}, [isWideScreen])
 	return (
 		<div className="flex h-16 items-center justify-between px-4">
 			{/* 🌟 Logo */}
@@ -82,16 +74,6 @@ export default function HeaderLayout(props: IHeaderLayoutProps) {
 						className="flex items-center"
 						size={16}
 					>
-						<div
-							className="flex cursor-pointer items-center"
-							onClick={() => setIsWideScreen(!isWideScreen)}
-							title={isWideScreen ? '切换窄屏' : '切换宽屏'}
-						>
-							<LucideIcon
-								name={isWideScreen ? 'shrink' : 'stretch-horizontal'}
-								size={20}
-							/>
-						</div>
 						<ThemeSelector>
 							<div className="flex cursor-pointer items-center">
 								<LucideIcon


### PR DESCRIPTION
## 概述

在聊天页面头部（主题切换按钮左侧）增加宽屏/窄屏切换按钮，支持聊天内容区域满屏展示。仅用户端聊天页显示，管理后台等其他页面不受影响。

## 变更

| 文件 | 变更 |
|---|---|
| `components/chat/chat-layout.tsx` | 新增 `stretch-horizontal/shrink` 图标切换按钮（通过 `rightIcon` prop 传入 `HeaderLayout`），`useLocalStorageState` 持久化状态，`useEffect` 在 `<html>` 上切换 `wide-screen` class |
| `app/globals.css` | `html.wide-screen` 下移除 `md:max-w-[720px]` 约束 |

## 行为

- 默认窄屏（居中 720px）
- 点击切换按钮 → 宽屏（全宽），状态持久化到 localStorage
- 刷新页面后保持上次选择
- 仅影响聊天内容区，侧边栏不受影响
- 仅在用户端聊天页显示，管理后台/登录等页面不出现

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a wide-screen mode toggle in the chat header. Users can now switch between compact and expanded layouts based on their preference.
  * Screen mode preference is automatically saved and persists across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lexmin0412/dify-chat/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->