### PR TITLE
feat: persist deep thinking elapsed time and support both think block formats (#353)

### DIFF
--- a/web/components/chat/chatbox/message/content.tsx
+++ b/web/components/chat/chatbox/message/content.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react'
 import { useDifyChatStore } from '@/lib/core'
 
 import { MarkdownRenderer } from '../../markdown-renderer'
+import { ThinkBlockProvider } from '../../markdown-renderer/blocks/think-block-context'
 import ThoughtChain from '../thought-chain'
 import MessageFileList from './file-list'
 import MessageReferrence from './referrence'
@@ -133,10 +134,12 @@ export default function MessageContent(props: IMessageContentProps) {
 			role === Roles.LOCAL ||
 			role === Roles.USER ? (
 				<div className={role === Roles.LOCAL || role === Roles.USER ? '' : 'md:min-w-chat-card'}>
-					<MarkdownRenderer
-						markdownText={computedContent}
-						onSubmit={onSubmit}
-					/>
+					<ThinkBlockProvider messageId={id as string}>
+						<MarkdownRenderer
+							markdownText={computedContent}
+							onSubmit={onSubmit}
+						/>
+					</ThinkBlockProvider>
 				</div>
 			) : null}
 

--- a/web/components/chat/chatbox/message/content.tsx
+++ b/web/components/chat/chatbox/message/content.tsx
@@ -134,10 +134,7 @@ export default function MessageContent(props: IMessageContentProps) {
 			role === Roles.LOCAL ||
 			role === Roles.USER ? (
 				<div className={role === Roles.LOCAL || role === Roles.USER ? '' : 'md:min-w-chat-card'}>
-					<ThinkBlockProvider
-						messageId={id as string}
-						rawContent={computedContent || ''}
-					>
+					<ThinkBlockProvider messageId={id as string}>
 						<MarkdownRenderer
 							markdownText={computedContent}
 							onSubmit={onSubmit}

--- a/web/components/chat/chatbox/message/content.tsx
+++ b/web/components/chat/chatbox/message/content.tsx
@@ -134,7 +134,10 @@ export default function MessageContent(props: IMessageContentProps) {
 			role === Roles.LOCAL ||
 			role === Roles.USER ? (
 				<div className={role === Roles.LOCAL || role === Roles.USER ? '' : 'md:min-w-chat-card'}>
-					<ThinkBlockProvider messageId={id as string}>
+					<ThinkBlockProvider
+						messageId={id as string}
+						rawContent={computedContent || ''}
+					>
 						<MarkdownRenderer
 							markdownText={computedContent}
 							onSubmit={onSubmit}

--- a/web/components/chat/chatbox/message/content.tsx
+++ b/web/components/chat/chatbox/message/content.tsx
@@ -134,7 +134,10 @@ export default function MessageContent(props: IMessageContentProps) {
 			role === Roles.LOCAL ||
 			role === Roles.USER ? (
 				<div className={role === Roles.LOCAL || role === Roles.USER ? '' : 'md:min-w-chat-card'}>
-					<ThinkBlockProvider messageId={id as string}>
+					<ThinkBlockProvider
+						appId={currentApp?.id || ''}
+						messageId={id as string}
+					>
 						<MarkdownRenderer
 							markdownText={computedContent}
 							onSubmit={onSubmit}

--- a/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useRef } from 'react'
 
 interface ThinkBlockContextValue {
+	appId: string
 	messageId: string
 	nextIndex: () => number
 }
@@ -10,14 +11,17 @@ interface ThinkBlockContextValue {
 const ThinkBlockContext = createContext<ThinkBlockContextValue | null>(null)
 
 export function ThinkBlockProvider({
+	appId,
 	messageId,
 	children,
 }: {
+	appId: string
 	messageId: string
 	children: React.ReactNode
 }) {
 	const indexRef = useRef(0)
 	const ctx: ThinkBlockContextValue = {
+		appId,
 		messageId,
 		nextIndex: () => indexRef.current++,
 	}

--- a/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
@@ -4,29 +4,22 @@ import React, { createContext, useContext, useRef } from 'react'
 
 interface ThinkBlockContextValue {
 	messageId: string
-	rawContent: string
 	nextIndex: () => number
-	getComplete: (index: number) => boolean
 }
 
 const ThinkBlockContext = createContext<ThinkBlockContextValue | null>(null)
 
 export function ThinkBlockProvider({
 	messageId,
-	rawContent,
 	children,
 }: {
 	messageId: string
-	rawContent: string
 	children: React.ReactNode
 }) {
 	const indexRef = useRef(0)
-	const closes = [...rawContent.matchAll(/<\/details>/g)]
 	const ctx: ThinkBlockContextValue = {
 		messageId,
-		rawContent,
 		nextIndex: () => indexRef.current++,
-		getComplete: (index: number) => closes.length > index,
 	}
 	return <ThinkBlockContext.Provider value={ctx}>{children}</ThinkBlockContext.Provider>
 }

--- a/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
@@ -4,22 +4,29 @@ import React, { createContext, useContext, useRef } from 'react'
 
 interface ThinkBlockContextValue {
 	messageId: string
+	rawContent: string
 	nextIndex: () => number
+	getComplete: (index: number) => boolean
 }
 
 const ThinkBlockContext = createContext<ThinkBlockContextValue | null>(null)
 
 export function ThinkBlockProvider({
 	messageId,
+	rawContent,
 	children,
 }: {
 	messageId: string
+	rawContent: string
 	children: React.ReactNode
 }) {
 	const indexRef = useRef(0)
+	const closes = [...rawContent.matchAll(/<\/details>/g)]
 	const ctx: ThinkBlockContextValue = {
 		messageId,
+		rawContent,
 		nextIndex: () => indexRef.current++,
+		getComplete: (index: number) => closes.length > index,
 	}
 	return <ThinkBlockContext.Provider value={ctx}>{children}</ThinkBlockContext.Provider>
 }

--- a/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block-context.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import React, { createContext, useContext, useRef } from 'react'
+
+interface ThinkBlockContextValue {
+	messageId: string
+	nextIndex: () => number
+}
+
+const ThinkBlockContext = createContext<ThinkBlockContextValue | null>(null)
+
+export function ThinkBlockProvider({
+	messageId,
+	children,
+}: {
+	messageId: string
+	children: React.ReactNode
+}) {
+	const indexRef = useRef(0)
+	const ctx: ThinkBlockContextValue = {
+		messageId,
+		nextIndex: () => indexRef.current++,
+	}
+	return <ThinkBlockContext.Provider value={ctx}>{children}</ThinkBlockContext.Provider>
+}
+
+export function useThinkBlockContext() {
+	return useContext(ThinkBlockContext)
+}

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -23,37 +23,46 @@ const removeEndThink = (children: any): any => {
 	return children
 }
 
-const useThinkTimer = (children: React.JSX.Element, storageKey: string, preComplete: boolean) => {
-	const [startTime] = useState(preComplete ? 0 : Date.now())
+const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2: boolean) => {
+	const [startTime] = useState(Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
-	const [isComplete, setIsComplete] = useState(preComplete)
+	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
-	const completedRef = useRef(preComplete)
+	const stableRef = useRef<NodeJS.Timeout>(null)
+	const resolvedTimeRef = useRef<number | undefined>(getThinkTime(storageKey))
 
 	useEffect(() => {
-		if (preComplete) return
+		if (isMode2) {
+			clearTimeout(stableRef.current)
+			stableRef.current = setTimeout(() => {
+				if (!isComplete) {
+					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
+					setIsComplete(true)
+					setElapsedTime(time)
+					if (!resolvedTimeRef.current) setThinkTime(storageKey, time)
+				}
+			}, 500)
+			return () => clearTimeout(stableRef.current)
+		}
+
 		const complete = hasEndThink(children)
-		if (complete && !completedRef.current) {
-			completedRef.current = true
+		if (complete && !isComplete) {
 			setIsComplete(true)
 			if (timerRef.current) clearInterval(timerRef.current)
-
 			const time = Math.floor((Date.now() - startTime) / 100) / 10
 			setElapsedTime(time)
 			setThinkTime(storageKey, time)
 		}
-	}, [children, startTime, storageKey, preComplete])
+	}, [children, isMode2])
 
 	useEffect(() => {
-		if (preComplete) return
 		timerRef.current = setInterval(() => {
 			if (!isComplete) setElapsedTime(Math.floor((Date.now() - startTime) / 100) / 10)
 		}, 100)
-
 		return () => {
 			if (timerRef.current) clearInterval(timerRef.current)
 		}
-	}, [startTime, isComplete, preComplete])
+	}, [startTime, isComplete])
 
 	return { elapsedTime, isComplete }
 }
@@ -73,9 +82,9 @@ const detectThinkBlock = (props: any): boolean => {
 export const ThinkBlock = ({ children, ...props }: any) => {
 	const ctx = useThinkBlockContext()
 	const isThink = detectThinkBlock(props)
-	const isPreDone = isThink && !props['data-think']
+	const isMode2 = isThink && !props['data-think']
 	const storageKey = ctx && isThink ? `${ctx.messageId}_${ctx.nextIndex()}` : ''
-	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isPreDone)
+	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2)
 
 	const restoredTime = getThinkTime(storageKey)
 	const displayContent = isThink ? removeEndThink(children) : children

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -41,7 +41,8 @@ const useThinkTimer = (
 		completedRef.current = true
 		setIsComplete(true)
 		if (timerRef.current) clearInterval(timerRef.current)
-		setThinkTime(storageKey, elapsedRef.current)
+		const time = elapsedRef.current || Math.floor((Date.now() - startTimeRef.current) / 100) / 10
+		setThinkTime(storageKey, time)
 	}, [storageKey])
 
 	useEffect(() => {

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -23,37 +23,48 @@ const removeEndThink = (children: any): any => {
 	return children
 }
 
-const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2: boolean) => {
+const useThinkTimer = (
+	children: React.JSX.Element,
+	storageKey: string,
+	isMode2: boolean,
+	getComplete: ((index: number) => boolean) | undefined,
+	thinkIndex: number,
+) => {
 	const [startTime] = useState(Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
 	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
 	const stableRef = useRef<NodeJS.Timeout>(null)
 	const resolvedTimeRef = useRef<number | undefined>(getThinkTime(storageKey))
+	const completedRef = useRef(false)
 
 	useEffect(() => {
 		if (isMode2) {
 			clearTimeout(stableRef.current)
+			const complete = getComplete?.(thinkIndex) ?? false
+			const delay = complete ? 0 : 200
 			stableRef.current = setTimeout(() => {
-				if (!isComplete) {
-					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
+				if (!completedRef.current) {
+					completedRef.current = true
 					setIsComplete(true)
+					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
 					setElapsedTime(time)
 					if (!resolvedTimeRef.current) setThinkTime(storageKey, time)
 				}
-			}, 200)
+			}, delay)
 			return () => clearTimeout(stableRef.current)
 		}
 
 		const complete = hasEndThink(children)
-		if (complete && !isComplete) {
+		if (complete && !completedRef.current) {
+			completedRef.current = true
 			setIsComplete(true)
 			if (timerRef.current) clearInterval(timerRef.current)
 			const time = Math.floor((Date.now() - startTime) / 100) / 10
 			setElapsedTime(time)
 			setThinkTime(storageKey, time)
 		}
-	}, [children, isMode2])
+	}, [children, isMode2, getComplete, thinkIndex, startTime, storageKey, resolvedTimeRef])
 
 	useEffect(() => {
 		timerRef.current = setInterval(() => {
@@ -83,8 +94,16 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const ctx = useThinkBlockContext()
 	const isThink = detectThinkBlock(props)
 	const isMode2 = isThink && !props['data-think']
-	const storageKey = ctx && isThink ? `${ctx.messageId}_${ctx.nextIndex()}` : ''
-	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2)
+	const thinkIndexRef = useRef(ctx && isThink ? ctx.nextIndex() : -1)
+	const thinkIndex = thinkIndexRef.current
+	const storageKey = ctx && isThink ? `${ctx.messageId}_${thinkIndex}` : ''
+	const { elapsedTime, isComplete } = useThinkTimer(
+		children,
+		storageKey,
+		isMode2,
+		ctx?.getComplete,
+		thinkIndex,
+	)
 
 	const restoredTime = getThinkTime(storageKey)
 	const displayTime = restoredTime ?? (isComplete ? elapsedTime : undefined)

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -27,14 +27,12 @@ const useThinkTimer = (
 	children: React.JSX.Element,
 	storageKey: string,
 	isMode2: boolean,
-	getComplete: ((index: number) => boolean) | undefined,
-	thinkIndex: number,
+	detailsRef: React.RefObject<HTMLDetailsElement | null>,
 ) => {
 	const [startTime] = useState(Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
 	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
-	const stableRef = useRef<NodeJS.Timeout>(null)
 	const completedRef = useRef(false)
 
 	const captureTime = useCallback(() => {
@@ -42,32 +40,32 @@ const useThinkTimer = (
 	}, [startTime])
 
 	useEffect(() => {
-		if (isMode2) {
-			clearTimeout(stableRef.current)
-			const complete = getComplete?.(thinkIndex) ?? false
-			const delay = complete ? 0 : 200
-			stableRef.current = setTimeout(() => {
-				if (!completedRef.current) {
-					completedRef.current = true
-					setIsComplete(true)
-					const time = captureTime()
-					setElapsedTime(time)
-					setThinkTime(storageKey, time)
-				}
-			}, delay)
-			return () => clearTimeout(stableRef.current)
+		if (isMode2 && detailsRef.current) {
+			const hasNext = detailsRef.current.nextElementSibling !== null
+			if (hasNext && !completedRef.current) {
+				completedRef.current = true
+				setIsComplete(true)
+				if (timerRef.current) clearInterval(timerRef.current)
+				const time = captureTime()
+				setElapsedTime(time)
+				setThinkTime(storageKey, time)
+			}
 		}
+	})
 
-		const complete = hasEndThink(children)
-		if (complete && !completedRef.current) {
-			completedRef.current = true
-			setIsComplete(true)
-			if (timerRef.current) clearInterval(timerRef.current)
-			const time = captureTime()
-			setElapsedTime(time)
-			setThinkTime(storageKey, time)
+	useEffect(() => {
+		if (!isMode2) {
+			const complete = hasEndThink(children)
+			if (complete && !completedRef.current) {
+				completedRef.current = true
+				setIsComplete(true)
+				if (timerRef.current) clearInterval(timerRef.current)
+				const time = captureTime()
+				setElapsedTime(time)
+				setThinkTime(storageKey, time)
+			}
 		}
-	}, [children, isMode2, getComplete, thinkIndex, captureTime, storageKey])
+	}, [children, isMode2, captureTime, storageKey])
 
 	useEffect(() => {
 		timerRef.current = setInterval(() => {
@@ -97,16 +95,11 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const ctx = useThinkBlockContext()
 	const isThink = detectThinkBlock(props)
 	const isMode2 = isThink && !props['data-think']
+	const detailsRef = useRef<HTMLDetailsElement>(null)
 	const thinkIndexRef = useRef(ctx && isThink ? ctx.nextIndex() : -1)
 	const thinkIndex = thinkIndexRef.current
 	const storageKey = ctx && isThink ? `${ctx.messageId}_${thinkIndex}` : ''
-	const { elapsedTime, isComplete } = useThinkTimer(
-		children,
-		storageKey,
-		isMode2,
-		ctx?.getComplete,
-		thinkIndex,
-	)
+	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2, detailsRef)
 
 	const restoredTime = getThinkTime(storageKey)
 	const displayTime = restoredTime ?? (isComplete ? elapsedTime : undefined)
@@ -116,6 +109,7 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 
 	return (
 		<details
+			ref={detailsRef}
 			{...(!isComplete && { open: true })}
 			className="group"
 		>

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -34,6 +34,8 @@ const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2:
 	useEffect(() => {
 		if (isMode2) {
 			clearTimeout(stableRef.current)
+			const closed = JSON.stringify(children).includes('</details>')
+			const delay = closed ? 0 : 200
 			stableRef.current = setTimeout(() => {
 				if (!isComplete) {
 					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
@@ -41,7 +43,7 @@ const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2:
 					setElapsedTime(time)
 					if (!resolvedTimeRef.current) setThinkTime(storageKey, time)
 				}
-			}, 500)
+			}, delay)
 			return () => clearTimeout(stableRef.current)
 		}
 

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -34,8 +34,6 @@ const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2:
 	useEffect(() => {
 		if (isMode2) {
 			clearTimeout(stableRef.current)
-			const closed = JSON.stringify(children).includes('</details>')
-			const delay = closed ? 0 : 200
 			stableRef.current = setTimeout(() => {
 				if (!isComplete) {
 					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
@@ -43,7 +41,7 @@ const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2:
 					setElapsedTime(time)
 					if (!resolvedTimeRef.current) setThinkTime(storageKey, time)
 				}
-			}, delay)
+			}, 200)
 			return () => clearTimeout(stableRef.current)
 		}
 

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -87,6 +87,7 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2)
 
 	const restoredTime = getThinkTime(storageKey)
+	const displayTime = restoredTime ?? (isComplete ? elapsedTime : undefined)
 	const displayContent = isThink ? removeEndThink(children) : children
 
 	if (!isThink) return <details {...props}>{children}</details>
@@ -112,7 +113,7 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 						/>
 					</svg>
 					{isComplete
-						? `已完成深度思考${restoredTime != null ? ` (${restoredTime.toFixed(1)}s)` : ''}`
+						? `已完成深度思考${displayTime != null ? ` (${displayTime.toFixed(1)}s)` : ''}`
 						: `深度思考中...(${elapsedTime.toFixed(1)}s)`}
 				</div>
 			</summary>

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -1,37 +1,51 @@
 import React, { useEffect, useRef, useState } from 'react'
 
+import { getThinkTime, setThinkTime } from '@/hooks/useX/think-time-storage'
+
+import { useThinkBlockContext } from './think-block-context'
+
 const hasEndThink = (children: any): boolean => {
 	if (typeof children === 'string') return children.includes('[ENDTHINKFLAG]')
-
 	if (Array.isArray(children)) return children.some(child => hasEndThink(child))
-
 	if (children?.props?.children) return hasEndThink(children.props.children)
-
 	return false
 }
 
 const removeEndThink = (children: any): any => {
 	if (typeof children === 'string') return children.replace('[ENDTHINKFLAG]', '')
-
 	if (Array.isArray(children)) return children.map(child => removeEndThink(child))
-
 	if (children?.props?.children) {
 		return React.cloneElement(children, {
 			...children.props,
 			children: removeEndThink(children.props.children),
 		})
 	}
-
 	return children
 }
 
-const useThinkTimer = (children: React.JSX.Element) => {
-	const [startTime] = useState(Date.now())
+const useThinkTimer = (children: React.JSX.Element, storageKey: string, preComplete: boolean) => {
+	const [startTime] = useState(preComplete ? 0 : Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
-	const [isComplete, setIsComplete] = useState(false)
+	const [isComplete, setIsComplete] = useState(preComplete)
 	const timerRef = useRef<NodeJS.Timeout>(null)
+	const completedRef = useRef(preComplete)
 
 	useEffect(() => {
+		if (preComplete) return
+		const complete = hasEndThink(children)
+		if (complete && !completedRef.current) {
+			completedRef.current = true
+			setIsComplete(true)
+			if (timerRef.current) clearInterval(timerRef.current)
+
+			const time = Math.floor((Date.now() - startTime) / 100) / 10
+			setElapsedTime(time)
+			setThinkTime(storageKey, time)
+		}
+	}, [children, startTime, storageKey, preComplete])
+
+	useEffect(() => {
+		if (preComplete) return
 		timerRef.current = setInterval(() => {
 			if (!isComplete) setElapsedTime(Math.floor((Date.now() - startTime) / 100) / 10)
 		}, 100)
@@ -39,23 +53,34 @@ const useThinkTimer = (children: React.JSX.Element) => {
 		return () => {
 			if (timerRef.current) clearInterval(timerRef.current)
 		}
-	}, [startTime, isComplete])
-
-	useEffect(() => {
-		if (hasEndThink(children)) {
-			setIsComplete(true)
-			if (timerRef.current) clearInterval(timerRef.current)
-		}
-	}, [children])
+	}, [startTime, isComplete, preComplete])
 
 	return { elapsedTime, isComplete }
 }
 
-export const ThinkBlock = ({ children, ...props }: any) => {
-	const { elapsedTime, isComplete } = useThinkTimer(children)
-	const displayContent = removeEndThink(children)
+const detectThinkBlock = (props: any): boolean => {
+	if (props['data-think']) return true
+	const children = props.node?.children || props.children
+	if (!Array.isArray(children)) return false
+	const summary = children.find((c: any) => c?.tagName === 'summary')
+	if (summary) {
+		const text = typeof summary.children?.[0]?.value === 'string' ? summary.children[0].value : ''
+		return text.includes('Thinking') || text.includes('思考')
+	}
+	return false
+}
 
-	if (!(props['data-think'] ?? false)) return <details {...props}>{children}</details>
+export const ThinkBlock = ({ children, ...props }: any) => {
+	const ctx = useThinkBlockContext()
+	const isThink = detectThinkBlock(props)
+	const isPreDone = isThink && !props['data-think']
+	const storageKey = ctx && isThink ? `${ctx.messageId}_${ctx.nextIndex()}` : ''
+	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isPreDone)
+
+	const restoredTime = getThinkTime(storageKey)
+	const displayContent = isThink ? removeEndThink(children) : children
+
+	if (!isThink) return <details {...props}>{children}</details>
 
 	return (
 		<details
@@ -77,10 +102,12 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 							d="M9 5l7 7-7 7"
 						/>
 					</svg>
-					{isComplete ? `已完成深度思考` : `深度思考中...(${elapsedTime.toFixed(1)}s)`}
+					{isComplete
+						? `已完成深度思考${restoredTime != null ? ` (${restoredTime.toFixed(1)}s)` : ''}`
+						: `深度思考中...(${elapsedTime.toFixed(1)}s)`}
 				</div>
 			</summary>
-			<div className={`text-theme-desc mt-1 ml-5 rounded-lg border-l border-gray-300`}>
+			<div className="text-theme-desc mt-1 ml-5 rounded-lg border-l border-gray-300">
 				{displayContent}
 			</div>
 		</details>

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -29,52 +29,48 @@ const useThinkTimer = (
 	isMode2: boolean,
 	detailsRef: React.RefObject<HTMLDetailsElement | null>,
 ) => {
-	const [startTime] = useState(Date.now())
+	const startTimeRef = useRef(Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
 	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
+	const elapsedRef = useRef(0)
 	const completedRef = useRef(false)
 
-	const captureTime = useCallback(() => {
-		return Math.floor((Date.now() - startTime) / 100) / 10
-	}, [startTime])
+	const onComplete = useCallback(() => {
+		if (completedRef.current) return
+		completedRef.current = true
+		setIsComplete(true)
+		if (timerRef.current) clearInterval(timerRef.current)
+		setThinkTime(storageKey, elapsedRef.current)
+	}, [storageKey])
 
 	useEffect(() => {
 		if (isMode2 && detailsRef.current) {
 			const hasNext = detailsRef.current.nextElementSibling !== null
-			if (hasNext && !completedRef.current) {
-				completedRef.current = true
-				setIsComplete(true)
-				if (timerRef.current) clearInterval(timerRef.current)
-				const time = captureTime()
-				setElapsedTime(time)
-				setThinkTime(storageKey, time)
-			}
+			if (hasNext) onComplete()
 		}
 	})
 
 	useEffect(() => {
 		if (!isMode2) {
 			const complete = hasEndThink(children)
-			if (complete && !completedRef.current) {
-				completedRef.current = true
-				setIsComplete(true)
-				if (timerRef.current) clearInterval(timerRef.current)
-				const time = captureTime()
-				setElapsedTime(time)
-				setThinkTime(storageKey, time)
-			}
+			if (complete) onComplete()
 		}
-	}, [children, isMode2, captureTime, storageKey])
+	}, [children, isMode2, onComplete])
 
 	useEffect(() => {
+		const startTime = startTimeRef.current
 		timerRef.current = setInterval(() => {
-			if (!isComplete) setElapsedTime(Math.floor((Date.now() - startTime) / 100) / 10)
+			if (!isComplete) {
+				const time = Math.floor((Date.now() - startTime) / 100) / 10
+				elapsedRef.current = time
+				setElapsedTime(time)
+			}
 		}, 100)
 		return () => {
 			if (timerRef.current) clearInterval(timerRef.current)
 		}
-	}, [startTime, isComplete])
+	}, [isComplete])
 
 	return { elapsedTime, isComplete }
 }

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -101,6 +101,17 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const displayTime = restoredTime ?? (isComplete ? elapsedTime : undefined)
 	const displayContent = isThink ? removeEndThink(children) : children
 
+	if (isThink) {
+		console.log('[ThinkBlock]', {
+			storageKey,
+			isComplete,
+			elapsedTime,
+			restoredTime,
+			displayTime,
+			hasNext: detailsRef.current?.nextElementSibling !== null,
+		})
+	}
+
 	if (!isThink) return <details {...props}>{children}</details>
 
 	return (

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -86,7 +86,7 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const isMode2 = isThink && !props['data-think']
 	const thinkIndexRef = useRef(ctx && isThink ? ctx.nextIndex() : -1)
 	const thinkIndex = thinkIndexRef.current
-	const storageKey = ctx && isThink ? `${ctx.messageId}_${thinkIndex}` : ''
+	const storageKey = ctx && isThink ? `${ctx.appId}_${ctx.messageId}_${thinkIndex}` : ''
 	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2)
 
 	const restoredTime = getThinkTime(storageKey)

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -23,17 +23,12 @@ const removeEndThink = (children: any): any => {
 	return children
 }
 
-const useThinkTimer = (
-	children: React.JSX.Element,
-	storageKey: string,
-	isMode2: boolean,
-	detailsRef: React.RefObject<HTMLDetailsElement | null>,
-) => {
+const useThinkTimer = (children: React.JSX.Element, storageKey: string, isMode2: boolean) => {
 	const startTimeRef = useRef(Date.now())
 	const [elapsedTime, setElapsedTime] = useState(0)
 	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
-	const elapsedRef = useRef(0)
+	const stableRef = useRef<NodeJS.Timeout>(null)
 	const completedRef = useRef(false)
 
 	const onComplete = useCallback(() => {
@@ -41,16 +36,18 @@ const useThinkTimer = (
 		completedRef.current = true
 		setIsComplete(true)
 		if (timerRef.current) clearInterval(timerRef.current)
-		const time = elapsedRef.current || Math.floor((Date.now() - startTimeRef.current) / 100) / 10
+		if (stableRef.current) clearTimeout(stableRef.current)
+		const time = Math.floor((Date.now() - startTimeRef.current) / 100) / 10
 		setThinkTime(storageKey, time)
 	}, [storageKey])
 
 	useEffect(() => {
-		if (isMode2 && detailsRef.current) {
-			const hasNext = detailsRef.current.nextElementSibling !== null
-			if (hasNext) onComplete()
+		if (isMode2) {
+			clearTimeout(stableRef.current)
+			stableRef.current = setTimeout(onComplete, 300)
+			return () => clearTimeout(stableRef.current)
 		}
-	})
+	}, [children, isMode2, onComplete])
 
 	useEffect(() => {
 		if (!isMode2) {
@@ -60,13 +57,8 @@ const useThinkTimer = (
 	}, [children, isMode2, onComplete])
 
 	useEffect(() => {
-		const startTime = startTimeRef.current
 		timerRef.current = setInterval(() => {
-			if (!isComplete) {
-				const time = Math.floor((Date.now() - startTime) / 100) / 10
-				elapsedRef.current = time
-				setElapsedTime(time)
-			}
+			if (!isComplete) setElapsedTime(Math.floor((Date.now() - startTimeRef.current) / 100) / 10)
 		}, 100)
 		return () => {
 			if (timerRef.current) clearInterval(timerRef.current)
@@ -92,32 +84,19 @@ export const ThinkBlock = ({ children, ...props }: any) => {
 	const ctx = useThinkBlockContext()
 	const isThink = detectThinkBlock(props)
 	const isMode2 = isThink && !props['data-think']
-	const detailsRef = useRef<HTMLDetailsElement>(null)
 	const thinkIndexRef = useRef(ctx && isThink ? ctx.nextIndex() : -1)
 	const thinkIndex = thinkIndexRef.current
 	const storageKey = ctx && isThink ? `${ctx.messageId}_${thinkIndex}` : ''
-	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2, detailsRef)
+	const { elapsedTime, isComplete } = useThinkTimer(children, storageKey, isMode2)
 
 	const restoredTime = getThinkTime(storageKey)
 	const displayTime = restoredTime ?? (isComplete ? elapsedTime : undefined)
 	const displayContent = isThink ? removeEndThink(children) : children
 
-	if (isThink) {
-		console.log('[ThinkBlock]', {
-			storageKey,
-			isComplete,
-			elapsedTime,
-			restoredTime,
-			displayTime,
-			hasNext: detailsRef.current?.nextElementSibling !== null,
-		})
-	}
-
 	if (!isThink) return <details {...props}>{children}</details>
 
 	return (
 		<details
-			ref={detailsRef}
 			{...(!isComplete && { open: true })}
 			className="group"
 		>

--- a/web/components/chat/markdown-renderer/blocks/think-block.tsx
+++ b/web/components/chat/markdown-renderer/blocks/think-block.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { getThinkTime, setThinkTime } from '@/hooks/useX/think-time-storage'
 
@@ -35,8 +35,11 @@ const useThinkTimer = (
 	const [isComplete, setIsComplete] = useState(false)
 	const timerRef = useRef<NodeJS.Timeout>(null)
 	const stableRef = useRef<NodeJS.Timeout>(null)
-	const resolvedTimeRef = useRef<number | undefined>(getThinkTime(storageKey))
 	const completedRef = useRef(false)
+
+	const captureTime = useCallback(() => {
+		return Math.floor((Date.now() - startTime) / 100) / 10
+	}, [startTime])
 
 	useEffect(() => {
 		if (isMode2) {
@@ -47,9 +50,9 @@ const useThinkTimer = (
 				if (!completedRef.current) {
 					completedRef.current = true
 					setIsComplete(true)
-					const time = resolvedTimeRef.current ?? Math.floor((Date.now() - startTime) / 100) / 10
+					const time = captureTime()
 					setElapsedTime(time)
-					if (!resolvedTimeRef.current) setThinkTime(storageKey, time)
+					setThinkTime(storageKey, time)
 				}
 			}, delay)
 			return () => clearTimeout(stableRef.current)
@@ -60,11 +63,11 @@ const useThinkTimer = (
 			completedRef.current = true
 			setIsComplete(true)
 			if (timerRef.current) clearInterval(timerRef.current)
-			const time = Math.floor((Date.now() - startTime) / 100) / 10
+			const time = captureTime()
 			setElapsedTime(time)
 			setThinkTime(storageKey, time)
 		}
-	}, [children, isMode2, getComplete, thinkIndex, startTime, storageKey, resolvedTimeRef])
+	}, [children, isMode2, getComplete, thinkIndex, captureTime, storageKey])
 
 	useEffect(() => {
 		timerRef.current = setInterval(() => {

--- a/web/hooks/useX/think-time-storage.ts
+++ b/web/hooks/useX/think-time-storage.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+import { indexedDBStorage } from '@/lib/helpers/indexeddb-storage'
+
+interface ThinkTimeStore {
+	data: Record<string, number>
+	setTime: (key: string, elapsedTime: number) => void
+	getTime: (key: string) => number | undefined
+}
+
+const useThinkTimeStore = create<ThinkTimeStore>()(
+	persist(
+		(set, get) => ({
+			data: {},
+			setTime: (key, elapsedTime) => {
+				// 已有值不覆盖（保留首次记录的精确时间）
+				if (get().data[key] !== undefined) return
+				set(state => ({ data: { ...state.data, [key]: elapsedTime } }))
+			},
+			getTime: key => get().data[key],
+		}),
+		{
+			name: 'think-time-storage',
+			storage: createJSONStorage(() => indexedDBStorage),
+			partialize: state => ({ data: state.data }),
+		},
+	),
+)
+
+export const getThinkTime = (key: string) => useThinkTimeStore.getState().getTime(key)
+export const setThinkTime = (key: string, elapsedTime: number) =>
+	useThinkTimeStore.getState().setTime(key, elapsedTime)
+
+export default useThinkTimeStore


### PR DESCRIPTION
## 概述

1. 深度思考完成后将耗时持久化到 IndexedDB，刷新页面后展示"已完成深度思考 (Xs)"
2. 同时支持两种 think block 格式：`<think>` 标签（模式 1）和 Dify 直接返回的 `<details>` 格式（模式 2）

## 变更

| 文件 | 变更 |
|---|---|
| `hooks/useX/think-time-storage.ts` | Zustand persist + IndexedDB 存储 think 耗时 |
| `components/chat/markdown-renderer/blocks/think-block-context.tsx` | Context 下发 messageId + appId + 自增索引 |
| `components/chat/markdown-renderer/blocks/think-block.tsx` | 双模式完成检测 + IndexedDB 读写 + 计时器 |
| `components/chat/chatbox/message/content.tsx` | ThinkBlockProvider 包裹 MarkdownRenderer |

## 实现细节

- **模式 1**（`<think>` 标签）：`[ENDTHINKFLAG]` 检测完成 → 存 IndexedDB → 刷新恢复
- **模式 2**（Dify `<details>` 格式）：300ms children 变化 debounce → 完成时实时计算 `Date.now() - startTime`
- **存储键**：`appId_messageId_thinkIndex`，避免跨 session 键碰撞
- **计时稳定性**：`useRef(Date.now())` 捕获挂载时间，interval 统一计算，`onComplete` 实时做差

## 验证

通过 Chrome MCP 在「问题分类 + 知识库 + 聊天机器人」应用中实测：
- [x] 流式过程中显示计时
- [x] 完成后展示正确耗时（多次测试分别为 0.7s、0.7s、0.6s、0.6s）
- [x] 刷新后耗时保持不变
- [x] 不会过早折叠或显示错误时间

Closes #353