### PR TITLE
fix: malformed img tag in message_file event handler (#316)

### DIFF
--- a/web/components/chat/workflow-layout.tsx
+++ b/web/components/chat/workflow-layout.tsx
@@ -122,7 +122,7 @@ export default function WorkflowLayout() {
 							setWorkflowStatus('running')
 							setWorkflowItems([])
 						} else if (parsedData.event === EventEnum.WORKFLOW_FINISHED) {
-// @ts-expect-error FIXME: 类型兼容							workflows.status = 'finished'
+							// @ts-expect-error FIXME: 类型兼容							workflows.status = 'finished'
 							const { outputs, files } = parsedData.data || {}
 							const outputsLength = Object.keys(outputs)?.length
 							if (outputsLength > 0) {
@@ -169,7 +169,7 @@ export default function WorkflowLayout() {
 							})
 						}
 						if (parsedData.event === EventEnum.MESSAGE_FILE) {
-							result += `<img src=""${parsedData.url} />`
+							result += `<img src="${parsedData.url}" />`
 						}
 						if (parsedData.event === EventEnum.MESSAGE) {
 							const text = parsedData.answer

--- a/web/hooks/useX/x-provider.ts
+++ b/web/hooks/useX/x-provider.ts
@@ -264,7 +264,7 @@ export class CustomProvider<
 			} as unknown as ChatMessage
 		}
 		if (parsedData.event === EventEnum.MESSAGE_FILE) {
-			const newContent = originMessage?.content + `<img src=""${parsedData.url} />`
+			const newContent = originMessage?.content + `<img src="${parsedData.url}" />`
 			return {
 				...originMessage,
 				content: newContent,


### PR DESCRIPTION
## 概述

修复 `message_file` SSE 事件处理中 `<img>` 标签的双引号错误，导致图片 `src` 为空。

## 根因

```diff
- `<img src=""${parsedData.url} />`   // src="" → 空字符串，URL 变成孤立属性
+ `<img src="${parsedData.url}" />`   // 正确嵌套
```

两处同样 bug：`x-provider.ts`（Chat 模式）和 `workflow-layout.tsx`（Workflow/TGI 模式）。

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image rendering issues in workflow messages by correcting the HTML generation for image elements, ensuring proper display of images in message results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lexmin0412/dify-chat/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->